### PR TITLE
Remote build support

### DIFF
--- a/core/swift42Action/Dockerfile
+++ b/core/swift42Action/Dockerfile
@@ -39,8 +39,7 @@ RUN rm -rf /var/lib/apt/lists/* && apt-get clean && apt-get update \
 	&& locale-gen en_US.UTF-8
 
 # Add nim
-RUN  apt-get -y install curl \
- && curl https://preview-apigcp.nimbella.io/remoteBuild/nim-install-linux.sh | bash
+RUN curl https://apigcp.nimbella.io/downloads/nim/nim-install-linux.sh | bash
 
 ENV LANG="en_US.UTF-8" \
 	LANGUAGE="en_US:en" \

--- a/core/swift42Action/Dockerfile
+++ b/core/swift42Action/Dockerfile
@@ -39,7 +39,7 @@ RUN rm -rf /var/lib/apt/lists/* && apt-get clean && apt-get update \
 	&& locale-gen en_US.UTF-8
 
 # Add nim
-RUN  apt-get -y install curl
+RUN  apt-get -y install curl \
  && curl https://preview-apigcp.nimbella.io/remoteBuild/nim-install-linux.sh | bash
 
 ENV LANG="en_US.UTF-8" \

--- a/core/swift42Action/Dockerfile
+++ b/core/swift42Action/Dockerfile
@@ -55,6 +55,7 @@ COPY --from=builder_release /bin/proxy /bin/proxy_release
 RUN mv /bin/proxy_${GO_PROXY_BUILD_FROM} /bin/proxy
 ADD swiftbuild.py /bin/compile
 ADD swiftbuild.py.launcher.swift /bin/compile.launcher.swift
+ADD defaultBuild /bin/defaultBuild
 COPY _Whisk.swift /swiftAction/Sources/
 COPY Package.swift /swiftAction/
 COPY buildandrecord.py /swiftAction/

--- a/core/swift42Action/Dockerfile
+++ b/core/swift42Action/Dockerfile
@@ -38,6 +38,10 @@ RUN rm -rf /var/lib/apt/lists/* && apt-get clean && apt-get update \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& locale-gen en_US.UTF-8
 
+# Add nim
+RUN  apt-get -y install curl
+ && curl https://preview-apigcp.nimbella.io/remoteBuild/nim-install-linux.sh | bash
+
 ENV LANG="en_US.UTF-8" \
 	LANGUAGE="en_US:en" \
 	LC_ALL="en_US.UTF-8"

--- a/core/swift42Action/defaultBuild
+++ b/core/swift42Action/defaultBuild
@@ -1,0 +1,43 @@
+#!/bin/bash
+#
+# Nimbella CONFIDENTIAL
+# ---------------------
+#
+#   2018 - present Nimbella Corp
+#   All Rights Reserved.
+#
+# NOTICE:
+#
+# All information contained herein is, and remains the property of
+# Nimbella Corp and its suppliers, if any.  The intellectual and technical
+# concepts contained herein are proprietary to Nimbella Corp and its
+# suppliers and may be covered by U.S. and Foreign Patents, patents
+# in process, and are protected by trade secret or copyright law.
+#
+# Dissemination of this information or reproduction of this material
+# is strictly forbidden unless prior written permission is obtained
+# from Nimbella Corp.
+#
+
+# This build invokes the default ActionLoop build for swift when run remotely.
+# Note that it works when (1) there is a Package.swift and Sources (the multi-file case)
+# or (2) when there is a single .swift file.  It exits with an error otherwise.
+# It is my impression that this limitation is inherent in /bin/compile for swift.
+if [ -d "Sources" ] && [ -f "Package.swift" ]; then
+  CURRENT="$PWD"
+	pushd /swiftAction
+	$OW_COMPILER main $CURRENT $CURRENT
+	popd
+  else
+	COUNT=$(ls *.swift | wc -w)
+	if [ "$COUNT" != "1" ]; then
+		echo "Conditions for use of the default action are not met"
+		exit 1
+	fi
+	cp *.swift /swiftAction/exec
+	pushd /swiftAction
+	$OW_COMPILER main . .
+	popd
+	cp /swiftAction/exec .
+fi
+echo exec > .include


### PR DESCRIPTION
For swift we not only add the `nim` command but also a `defaultBuild` script which can be invoked explicitly in custom build.